### PR TITLE
Remove '+' from beginning of hash bang line

### DIFF
--- a/wsd.py
+++ b/wsd.py
@@ -1,4 +1,4 @@
-+#!/usr/bin/env python
+#!/usr/bin/env python
 # encoding: utf-8
 
 '''


### PR DESCRIPTION
A '+' seems to have found its to the front of the hash bang line in wsd.py.
